### PR TITLE
Changing 'alt' to 'title' in order to properly take into account accessibility considerations

### DIFF
--- a/jquery.captionate.js
+++ b/jquery.captionate.js
@@ -24,7 +24,7 @@
 		return this.each(function() { 
             
             var   $this = $(this), // save a reference to the current img.caption element
-                    altText = $this.attr('alt'), // grab the value of the image ALT attribute		
+                    altText = $this.attr('title'), // grab the value of the image ALT attribute		
                     imgWidth = $this.width(), // grab the width of the image
                     classList = $this.attr('class'); // save any classes attached to the <img>
 


### PR DESCRIPTION
You should never use the 'alt' attribute for anything other than screenreader descriptions, which may NOT be useful captions. Use the 'title' attribute instead to generate the captions.
